### PR TITLE
Expose openid well known endpoints

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,11 +12,13 @@ import http from 'http';
 import { appContainer } from './services/inversify.config';
 import { SocketManagerServiceInterface } from './services/interfaces';
 import { TYPES } from './services/types';
+
 import { credentialIssuerRouter } from './routers/credential_issuer.router';
 import { proxyRouter } from './routers/proxy.router';
 import { helperRouter } from './routers/helper.router';
 import { verifierRouter } from './routers/verifier.router';
 import { walletProviderRouter } from './routers/wallet_provider.router';
+import { openidRouter } from './routers/openid.router';
 
 
 const app: Express = express();
@@ -42,6 +44,7 @@ app.use(cors({
 app.use('/status', statusRouter);
 app.use('/user', userController);
 
+app.use('/.well-known', openidRouter);
 
 app.use(AuthMiddleware);
 

--- a/src/routers/openid.router.ts
+++ b/src/routers/openid.router.ts
@@ -1,0 +1,72 @@
+import { Router } from "express";
+
+import { config } from '../../config'
+
+const openidRouter = Router();
+
+// TODO credential static configuration
+const credentials = [
+  {
+    credentialConfiguration: {
+      'CredentialSdJwt': {
+        'scope': 'CredentialSdJwt',
+        'cryptographic_binding_methods_supported': ['ES256'],
+        'credential_signing_alg_values_supported': ['ES256'],
+        'proof_types_supported': {
+          'proof_signing_alg_values_supported': ['ES256']
+        },
+        'format': 'vc+sd-jwt',
+        'vct': 'urn:wwwallet:test',
+        'credential_definition': {
+          'credentialSubject': {
+            'username': [ { 'name': 'Username' } ]
+          },
+          'type': [
+            'VerifiableCredential',
+            'CredentialSdJwt'
+          ]
+        }
+      }
+    },
+    display: {
+      'background_color': '#ffd758',
+      'locale': 'en-US',
+      'name': 'Username (SD JWT)',
+      'text_color': '#333333'
+    }
+  }
+]
+
+const serverConfiguration = {
+	'issuer': config.url,
+	'authorization_endpoint': config.url + '/auth/authorize',
+	'token_endpoint': config.url + '/auth/token',
+	'pushed_authorization_request_endpoint': config.url + '/auth/pushed_authorization_request',
+	'response_types_supported': ['authorization_code']
+}
+
+const credentialIssuerConfiguration = {
+	'credential_issuer': config.url,
+	'credential_endpoint': config.url + '/openid/credential',
+	'authorization_servers': [
+    config.url
+  ],
+  'display': credentials.map(({ display }) => display),
+  'credential_configurations_supported': credentials.map(({ credentialConfiguration }) => credentialConfiguration)
+}
+
+openidRouter.get('/oauth-authorization-server', async (req, res) => {
+  res.send(serverConfiguration)
+})
+
+openidRouter.get('/openid-configuration', async (req, res) => {
+  res.send(serverConfiguration)
+})
+
+openidRouter.get('/openid-credential-issuer', async (req, res) => {
+  res.send(credentialIssuerConfiguration)
+})
+
+export {
+  openidRouter
+}


### PR DESCRIPTION
Implement server configuration endpoints as stated in OIDC for `openid-configuration` and OID4VCI for `openid-credential-issuer`.

Those follow the wallet frontend required formats helping it to parse it to start the issuance flow which can be triggered with links like 

http://localhost:3000/?credential_offer=%7B%22credential_configuration_ids%22%3A%5B%22CredentialSdJwt%22%5D%2C%22credential_issuer%22%3A%22http%3A%2F%2Fwallet-backend-server%3A8002%22%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%226YHQ8B025RMGd4Vrhx6PbaIY0GxIcVoUZccSfpaBvSIgkk5mRZReYufgjZuJSPIcC2cDoc7PFWIh4EYP7Vf5yK%22%7D%7D%7D

Navigating to such a link that would be obtained via a QR code (cross device) or a deeplink (same device) starts the flow given the support of pre-authorized code flow by the wallet that is yet to be implemented.